### PR TITLE
fix: 修复 db 删除数据异常时的方法调用错误

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -23,7 +23,7 @@ class DBCache {
   deleteEvent(event) {
     db.remove({ _id: event._id }, {}, function (err, numRemoved) {
       if (err) {
-        reject(err);
+        debug(err);
       }
     });
   }


### PR DESCRIPTION
可访问的作用域或 node.js 全局上都没有 `reject` 方法可供调用，原代码里应该是个 typo